### PR TITLE
feat(apply): Add per-step QA Autofill buttons for Mentee and Mentor applications

### DIFF
--- a/src/pages/apply/MenteeApplication.tsx
+++ b/src/pages/apply/MenteeApplication.tsx
@@ -11,6 +11,7 @@ import { ErrorSummary } from '@/components/application/ErrorSummary';
 import { useToast } from '@/hooks/use-toast';
 import Layout from '@/components/layout/Layout';
 import { Separator } from '@/components/ui/separator';
+import { MATRIX_CATEGORIES, getCurrentYears } from '@/data/applicationData';
 
 // Import step components
 import { MenteeStep1 } from './steps/mentee/MenteeStep1';
@@ -198,6 +199,167 @@ export const MenteeApplication: React.FC = () => {
     }
   };
 
+  const handleAutofillStep = (stepIndex: number) => {
+    // Utility to create a dummy uploaded file item compatible with FileUploader
+    const dummyFileItem = (name: string, type: string) => ({
+      id: Math.random().toString(36).slice(2),
+      file: new File(["Test content"], name, { type }),
+      progress: 100,
+      status: 'completed' as const,
+      url: ''
+    });
+
+    switch (stepIndex) {
+      case 0: {
+        form.setValue('applicant', {
+          firstName: 'John',
+          lastName: 'Doe',
+          email: 'john.doe@example.com',
+          title: 'Founder'
+        });
+        form.setValue('company', {
+          ...(form.getValues('company') || {}),
+          name: 'Acme Widgets',
+          type: 'LLC',
+          industry: ['Information Technology'],
+          website: 'https://example.com',
+          phoneBusiness: '8161234567'
+        });
+        form.setValue('applicant_phoneMobile', '8169876543');
+        form.setValue('referral', { source: 'Web Search' });
+        form.setValue('address', {
+          business: {
+            street1: '123 Main St',
+            street2: '',
+            city: 'Kansas City',
+            state: 'MO',
+            postalCode: '64101',
+            country: 'USA'
+          }
+        });
+        break;
+      }
+      case 1: {
+        form.setValue('company', {
+          ...(form.getValues('company') || {}),
+          yearsInBusiness: 5,
+          fiscalYearEnd: 'december',
+          founderIsApplicant: true,
+          ultimateDecisionMaker: true,
+          ownership: [
+            { name: 'John Doe', title: 'Founder', equityPercent: 80 },
+            { name: 'Jane Smith', title: 'Co-founder', equityPercent: 20 }
+          ]
+        });
+        form.setValue('governance', {
+          hasBoardOfDirectors: true,
+          hasAdvisoryBoard: false,
+          directorsCount: 3
+        });
+        break;
+      }
+      case 2: {
+        form.setValue('team', {
+          fullTime: 5,
+          partTime: 2,
+          contractors: 1,
+          total: 8
+        });
+        break;
+      }
+      case 3: {
+        const years = getCurrentYears();
+        const yearsData: any = {};
+        [years.last2, years.last1, years.currentEst].forEach((y) => {
+          yearsData[y] = {
+            fullTimeEmployees: 3,
+            annualRevenue: 250000 + (y === years.currentEst ? 50000 : 0),
+            revenueGrowthPercent: 20,
+            profitGrowthPercent: 15,
+            equityPercent: 75
+          };
+        });
+        form.setValue('finance', {
+          years: yearsData,
+          wasProfitableLastYear: true,
+          currentlyProfitable: true,
+          largestCustomerSharePercent: 30,
+          takesAnnualSalary: true,
+          contextNotes: 'Autofilled financial snapshot for testing.'
+        });
+        break;
+      }
+      case 4: {
+        const matrix: Record<string, string> = {};
+        MATRIX_CATEGORIES.forEach((c) => { matrix[c.id] = 'S'; });
+        form.setValue('strengths', { matrix });
+        const longText =
+          'This is an autofilled narrative used for testing the form validation. '.repeat(8);
+        const longText2 =
+          'We are seeking mentorship to accelerate growth and improve operations. '.repeat(8);
+        form.setValue('narratives', {
+          biggestSuccess: longText,
+          helpAreas: longText2,
+          extraStrength: 'Team collaboration and innovation.',
+          extraHelp: 'Scaling sales processes.',
+          mistakes: [
+            { whatHappened: 'Made a hiring decision too quickly without due diligence.'.repeat(2), lesson: 'Implemented structured interviews and reference checks.'.repeat(2) },
+            { whatHappened: 'Underestimated project scope leading to delays.'.repeat(2), lesson: 'Now perform detailed planning and risk assessment.'.repeat(2) },
+            { whatHappened: 'Launched without enough user testing.'.repeat(2), lesson: 'We added a beta program and feedback loops.'.repeat(2) }
+          ],
+          whyHEMP: 'HEMP will provide invaluable guidance, accountability, and network access to help us scale responsibly and sustainably. '.repeat(4)
+        });
+        break;
+      }
+      case 5: {
+        form.setValue('references', {
+          accountant: { name: 'Alice Accountant', firm: 'AA CPA', phone: '8165551000', email: 'alice@cpa.com' },
+          attorney: { name: 'Bob Attorney', firm: 'BA Law', phone: '8165552000', email: 'bob@law.com' },
+          bank: { name: 'Carol Banker', bankName: 'KC Bank', phone: '8165553000', email: 'carol@kcbank.com' },
+          business: [
+            { name: 'Dave Biz', company: 'BizCo', phone: '8165554000', email: 'dave@biz.co' },
+            { name: 'Eve Biz', company: 'Enterprises', phone: '8165555000', email: 'eve@enterprises.com' }
+          ],
+          customer: [
+            { name: 'Frank Customer', company: 'CustCorp', phone: '8165556000', email: 'frank@cust.com' },
+            { name: 'Grace Customer', company: 'Grace LLC', phone: '8165557000', email: 'grace@grace.com' }
+          ],
+          supplier: [
+            { name: 'Heidi Supplier', company: 'SupplyCo', phone: '8165558000', email: 'heidi@supply.co' },
+            { name: 'Ivan Supplier', company: 'Widgets Ltd', phone: '8165559000', email: 'ivan@widgets.com' }
+          ]
+        });
+        break;
+      }
+      case 6: {
+        form.setValue('uploads', {
+          coverLetter: [dummyFileItem('cover-letter.pdf', 'application/pdf')],
+          orgChart: [dummyFileItem('org-chart.pdf', 'application/pdf')],
+          personalBioOrResume: [dummyFileItem('resume.pdf', 'application/pdf')],
+          businessDescription: [dummyFileItem('business-description.pdf', 'application/pdf')],
+          releaseGeneral: [dummyFileItem('general-release.pdf', 'application/pdf')],
+          releaseInfoAuthorization: [dummyFileItem('info-authorization.pdf', 'application/pdf')],
+          releaseApplicationInfo: [dummyFileItem('application-release.pdf', 'application/pdf')],
+          headshot: [dummyFileItem('headshot.jpg', 'image/jpeg')]
+        });
+        break;
+      }
+      case 7: {
+        form.setValue('signature', {
+          typedName: 'John Doe',
+          consent: true,
+          drawn: '',
+          method: 'typed',
+          timestamp: new Date().toISOString(),
+          ip: '127.0.0.1'
+        });
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
   return (
     <Layout>
       <div className="container mx-auto py-8 max-w-4xl">
@@ -213,6 +375,17 @@ export const MenteeApplication: React.FC = () => {
             <div className="flex justify-between items-center">
               <CardTitle className="text-xl">Application Progress</CardTitle>
               <AutosaveIndicator status={autosaveStatus} lastSaved={lastSaved} />
+              <div className="flex items-center gap-2">
+                <Button type="button" variant="secondary" onClick={() => handleAutofillStep(currentStep)}>
+                  Autofill This Step
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => { handleAutofillStep(currentStep); if (currentStep < STEPS.length - 1) setCurrentStep(currentStep + 1); }}>
+                  Autofill & Next
+                </Button>
+                <Button type="button" variant="outline" onClick={() => { for (let i = 0; i < 8; i++) handleAutofillStep(i); }}>
+                  Autofill All Steps
+                </Button>
+              </div>
             </div>
           </CardHeader>
           <CardContent>

--- a/src/pages/apply/MenteeApplication.tsx
+++ b/src/pages/apply/MenteeApplication.tsx
@@ -382,7 +382,7 @@ export const MenteeApplication: React.FC = () => {
                 <Button type="button" variant="secondary" onClick={() => { handleAutofillStep(currentStep); if (currentStep < STEPS.length - 1) setCurrentStep(currentStep + 1); }}>
                   Autofill & Next
                 </Button>
-                <Button type="button" variant="outline" onClick={() => { for (let i = 0; i < 8; i++) handleAutofillStep(i); }}>
+                <Button type="button" variant="outline" onClick={() => { for (let i = 0; i < 8; i++) handleAutofillStep(i); setCurrentStep(STEPS.length - 1); }}>
                   Autofill All Steps
                 </Button>
               </div>

--- a/src/pages/apply/MenteeApplication.tsx
+++ b/src/pages/apply/MenteeApplication.tsx
@@ -360,6 +360,11 @@ export const MenteeApplication: React.FC = () => {
     }
   };
 
+  const autofillAllSteps = () => {
+    for (let i = 0; i < STEPS.length - 1; i++) handleAutofillStep(i);
+    setCurrentStep(STEPS.length - 1);
+  };
+
   return (
     <Layout>
       <div className="container mx-auto py-8 max-w-4xl">
@@ -382,7 +387,7 @@ export const MenteeApplication: React.FC = () => {
                 <Button type="button" variant="secondary" onClick={() => { handleAutofillStep(currentStep); if (currentStep < STEPS.length - 1) setCurrentStep(currentStep + 1); }}>
                   Autofill & Next
                 </Button>
-                <Button type="button" variant="outline" onClick={() => { for (let i = 0; i < 8; i++) handleAutofillStep(i); setCurrentStep(STEPS.length - 1); }}>
+                <Button type="button" variant="outline" onClick={autofillAllSteps}>
                   Autofill All Steps
                 </Button>
               </div>

--- a/src/pages/apply/MentorApplication.tsx
+++ b/src/pages/apply/MentorApplication.tsx
@@ -11,6 +11,7 @@ import { ErrorSummary } from '@/components/application/ErrorSummary';
 import { useToast } from '@/hooks/use-toast';
 import Layout from '@/components/layout/Layout';
 import { Separator } from '@/components/ui/separator';
+import { MATRIX_CATEGORIES, EXPERTISE_AREAS, MEETING_PREFERENCES } from '@/data/applicationData';
 
 // Import step components
 import { MentorStep1 } from './steps/mentor/MentorStep1';
@@ -192,6 +193,102 @@ export const MentorApplication: React.FC = () => {
     }
   };
 
+  const handleAutofillStep = (stepIndex: number) => {
+    const dummyFileItem = (name: string, type: string) => ({
+      id: Math.random().toString(36).slice(2),
+      file: new File(["Test content"], name, { type }),
+      progress: 100,
+      status: 'completed' as const,
+      url: ''
+    });
+
+    switch (stepIndex) {
+      case 0: {
+        form.setValue('person', {
+          firstName: 'Mary',
+          lastName: 'Mentor',
+          email: 'mary.mentor@example.com',
+          title: 'Executive Advisor'
+        });
+        form.setValue('company', {
+          name: 'MentorCo',
+          industry: ['Professional Services'],
+          website: 'https://mentor.co'
+        });
+        form.setValue('phones', { business: '9135550000', mobile: '9135551111' });
+        form.setValue('address', {
+          business: { street1: '500 Market St', street2: '', city: 'Overland Park', state: 'KS', postalCode: '66210', country: 'USA' }
+        });
+        form.setValue('referral', { source: 'Alumni' });
+        break;
+      }
+      case 1: {
+        form.setValue('background', { yearsInLeadershipOrOwnership: 15 });
+        form.setValue('team', { fullTime: 20, partTime: 5, contractors: 3, total: 28 });
+        form.setValue('company', { ...(form.getValues('company') || {}), type: 'LLC', typeOther: '', experienceNotes: 'Autofilled.' });
+        break;
+      }
+      case 2: {
+        form.setValue('preferences', {
+          expertiseAreas: EXPERTISE_AREAS.slice(0, 3),
+          availabilityHoursPerMonth: 6,
+          meetingPreference: MEETING_PREFERENCES[2],
+          capacityMentees: 2,
+          geography: 'KC Metro',
+          notes: 'Open to remote sessions.'
+        });
+        break;
+      }
+      case 3: {
+        const matrix: Record<string, string> = {};
+        MATRIX_CATEGORIES.forEach((c) => { matrix[c.id] = 'S'; });
+        form.setValue('strengths', { matrix });
+        form.setValue('narratives', {
+          biggestSuccess: 'Helped scale a startup to national presence with strong revenue growth. '.repeat(5),
+          mistakes: [
+            { whatHappened: 'Delegated too little early on leading to bottlenecks.'.repeat(2), lesson: 'Empowered team leads and established clear processes.'.repeat(2) },
+            { whatHappened: 'Expanded to a new market without sufficient research.'.repeat(2), lesson: 'Now validate with pilots and customer discovery.'.repeat(2) },
+            { whatHappened: 'Hired for skill without culture fit.'.repeat(2), lesson: 'We created values-based hiring criteria.'.repeat(2) }
+          ],
+          helpAreasAsLeader: 'Seeking to improve mentorship frameworks for early-stage founders. '.repeat(4),
+          whyHEMP: 'Committed to giving back and supporting the next generation of entrepreneurs. '.repeat(4)
+        });
+        break;
+      }
+      case 4: {
+        form.setValue('references', {
+          business: [
+            { name: 'Alan Ref', company: 'Alpha Inc', phone: '9135552000', email: 'alan@alpha.com' },
+            { name: 'Betty Ref', company: 'Beta LLC', phone: '9135553000', email: 'betty@beta.com' },
+            { name: 'Carl Ref', company: 'Gamma Co', phone: '9135554000', email: 'carl@gamma.com' }
+          ]
+        });
+        break;
+      }
+      case 5: {
+        form.setValue('uploads', {
+          bio: [dummyFileItem('bio.pdf', 'application/pdf')],
+          headshot: [dummyFileItem('mentor-headshot.jpg', 'image/jpeg')],
+          additionalDocs: [dummyFileItem('portfolio.pdf', 'application/pdf')]
+        });
+        break;
+      }
+      case 6: {
+        form.setValue('signature', {
+          typedName: 'Mary Mentor',
+          consent: true,
+          drawn: '',
+          method: 'typed',
+          timestamp: new Date().toISOString(),
+          ip: '127.0.0.1'
+        });
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
   return (
     <Layout>
       <div className="container mx-auto py-8 max-w-4xl">
@@ -207,6 +304,17 @@ export const MentorApplication: React.FC = () => {
             <div className="flex justify-between items-center">
               <CardTitle className="text-xl">Application Progress</CardTitle>
               <AutosaveIndicator status={autosaveStatus} lastSaved={lastSaved} />
+              <div className="flex items-center gap-2">
+                <Button type="button" variant="secondary" onClick={() => handleAutofillStep(currentStep)}>
+                  Autofill This Step
+                </Button>
+                <Button type="button" variant="secondary" onClick={() => { handleAutofillStep(currentStep); if (currentStep < STEPS.length - 1) setCurrentStep(currentStep + 1); }}>
+                  Autofill & Next
+                </Button>
+                <Button type="button" variant="outline" onClick={() => { for (let i = 0; i < 7; i++) handleAutofillStep(i); }}>
+                  Autofill All Steps
+                </Button>
+              </div>
             </div>
           </CardHeader>
           <CardContent>

--- a/src/pages/apply/MentorApplication.tsx
+++ b/src/pages/apply/MentorApplication.tsx
@@ -311,7 +311,7 @@ export const MentorApplication: React.FC = () => {
                 <Button type="button" variant="secondary" onClick={() => { handleAutofillStep(currentStep); if (currentStep < STEPS.length - 1) setCurrentStep(currentStep + 1); }}>
                   Autofill & Next
                 </Button>
-                <Button type="button" variant="outline" onClick={() => { for (let i = 0; i < 7; i++) handleAutofillStep(i); }}>
+                <Button type="button" variant="outline" onClick={() => { for (let i = 0; i < 7; i++) handleAutofillStep(i); setCurrentStep(STEPS.length - 1); }}>
                   Autofill All Steps
                 </Button>
               </div>

--- a/src/pages/apply/MentorApplication.tsx
+++ b/src/pages/apply/MentorApplication.tsx
@@ -289,6 +289,11 @@ export const MentorApplication: React.FC = () => {
     }
   };
 
+  const autofillAllSteps = () => {
+    for (let i = 0; i < STEPS.length - 1; i++) handleAutofillStep(i);
+    setCurrentStep(STEPS.length - 1);
+  };
+
   return (
     <Layout>
       <div className="container mx-auto py-8 max-w-4xl">
@@ -311,7 +316,7 @@ export const MentorApplication: React.FC = () => {
                 <Button type="button" variant="secondary" onClick={() => { handleAutofillStep(currentStep); if (currentStep < STEPS.length - 1) setCurrentStep(currentStep + 1); }}>
                   Autofill & Next
                 </Button>
-                <Button type="button" variant="outline" onClick={() => { for (let i = 0; i < 7; i++) handleAutofillStep(i); setCurrentStep(STEPS.length - 1); }}>
+                <Button type="button" variant="outline" onClick={autofillAllSteps}>
                   Autofill All Steps
                 </Button>
               </div>


### PR DESCRIPTION
Summary
- Adds fast QA Autofill controls to both Mentee and Mentor multi-step applications:
  - "Autofill This Step"
  - "Autofill & Next"
  - "Autofill All Steps" (fills data steps only, then jumps to Summary)
- Implements handleAutofillStep(stepIndex) with realistic dummy data respecting zod/react-hook-form schemas
- Simulates FileUploader items where relevant to pass validation
- Extracts autofillAllSteps helpers that fill all non-summary steps and navigate to last step

Details
- Mentee: steps 0–7 are auto-populated; summary is excluded
- Mentor: steps 0–6 are auto-populated; summary is excluded
- Data includes personal/company info, governance, team, finance snapshots (mentee), background/preferences/strengths/references (mentor), and signature fields
- UI added to the Application Progress header in both pages

Why
- Speeds manual QA and validation by quickly traversing steps
- Useful for demo and reviewer flows without typing repetitive inputs

Notes
- No dependency changes
- Buttons are always visible; can be gated behind an env flag later if desired
- LocalStorage keys: "mentee-application" and "mentor-application"

Testing
- TypeScript compiles locally
- Manual flow tested with autofill per-step and bulk navigation

Co-authored-by: openhands <openhands@all-hands.dev>